### PR TITLE
Add a PromptDialog testing component

### DIFF
--- a/components/component.js
+++ b/components/component.js
@@ -1,0 +1,114 @@
+const Ci = Components.interfaces;
+
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+
+XPCOMUtils.defineLazyServiceGetter(Services, "embedlite",
+                                    "@mozilla.org/embedlite-app-service;1",
+                                    "nsIEmbedAppService");
+
+
+Services.scriptloader.loadSubScript("chrome://embedlite/content/Logger.js");
+
+function ExampleComponent() {
+  Logger.debug("JSComp: ExampleComponent.js loaded");
+}
+
+ExampleComponent.prototype = {
+  classID: Components.ID("{20227a22-1722-4753-b8f7-c842b401b4c3}"),
+
+  QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver]),
+
+  __promptService : null, // Prompt service for user interaction
+  get _promptService() {
+    if (!this.__promptService)
+      this.__promptService =
+          Cc["@mozilla.org/embedcomp/prompt-service;1"].
+          getService(Ci.nsIPromptService);
+    return this.__promptService;
+  },
+
+  observe: function(aSubject, aTopic, aData) {
+    switch (aTopic) {
+    case "app-startup":
+      Services.obs.addObserver(this, "exampleTopic", false);
+      break;
+    case "exampleTopic":
+      Logger.debug("ExampleComponent: exampleTopic data: " + aData);
+
+      // Change the prompt here to test different types
+      // This file will be installed to /usr/share/harbour-webview/components/component.js
+      // and can be edited directly
+
+      this.triggerConfirm();
+      //this.triggerAlert();
+      //this.triggerPrompt();
+      //this.triggerPromptUsernameAndPassword();
+      //this.triggerPromptPassword();
+      //this.triggerSelect();
+      break;
+    }
+  },
+
+  // Developer prompt generation
+  // For all available prompt types and parameters see:
+  // gecko-dev/toolkit/components/windowwatcher/nsIPromptService.idl
+
+  triggerConfirm: function() {
+    Logger.debug("JSComp: ExampleComponent.js confirm");
+    var check = { "value": false };
+    let buttonFlags = Ci.nsIPromptService.BUTTON_TITLE_REVERT + (Ci.nsIPromptService.BUTTON_TITLE_SAVE << 8);
+    let result = this._promptService.confirmEx(Services.ww.activeWindow, "Title", "text", buttonFlags, null, null, null, "Check", check);
+    Logger.debug("JSComp: ExampleComponent.js confirm result: " + result);
+    Logger.debug("JSComp: ExampleComponent.js check: " + check.value);
+  },
+
+  triggerAlert: function() {
+    Logger.debug("JSComp: ExampleComponent.js alert");
+    this._promptService.alert(Services.ww.activeWindow, "Title", "text");
+    Logger.debug("JSComp: ExampleComponent.js alert has no result");
+  },
+
+  triggerPrompt: function() {
+    Logger.debug("JSComp: ExampleComponent.js prompt");
+    var check = { "value": false };
+    var value = { "value": "value" }
+    let result = this._promptService.prompt(Services.ww.activeWindow, "Title", "text", value, "Value string", check);
+    Logger.debug("JSComp: ExampleComponent.js prompt result: " + result);
+    Logger.debug("JSComp: ExampleComponent.js value: " + JSON.stringify(value));
+    Logger.debug("JSComp: ExampleComponent.js check: " + check.value);
+  },
+
+  triggerPromptUsernameAndPassword: function() {
+    Logger.debug("JSComp: ExampleComponent.js promptUsernameAndPassword");
+    var check = { "value": false };
+    var username = { "value": "Username"};
+    var password = { "value": "Password"};
+    let result = this._promptService.promptUsernameAndPassword(Services.ww.activeWindow, "Title", "text", username, password, "Check message", check);
+    Logger.debug("JSComp: ExampleComponent.js promptUsernameAndPassword result: " + result);
+    Logger.debug("JSComp: ExampleComponent.js username: " + JSON.stringify(username));
+    Logger.debug("JSComp: ExampleComponent.js password: " + JSON.stringify(password));
+    Logger.debug("JSComp: ExampleComponent.js check: " + check.value);
+  },
+
+  triggerPromptPassword: function() {
+    Logger.debug("JSComp: ExampleComponent.js promptPassword");
+    var check = { "value": false };
+    var password = { "value": "Password"};
+    let result = this._promptService.promptPassword(Services.ww.activeWindow, "Title", "text", password, "Check message", check);
+    Logger.debug("JSComp: ExampleComponent.js promptPassword result: " + result);
+    Logger.debug("JSComp: ExampleComponent.js password: " + JSON.stringify(password));
+    Logger.debug("JSComp: ExampleComponent.js check: " + check.value);
+  },
+
+  triggerSelect: function() {
+    Logger.debug("JSComp: ExampleComponent.js select");
+    var items = ["First", "Second", "Third"];
+    var selection = { "value": 0 };
+    let result = this._promptService.select(Services.ww.activeWindow, "Title", "text", items.length, items, selection);
+    Logger.debug("JSComp: ExampleComponent.js select result: " + result);
+    Logger.debug("JSComp: ExampleComponent.js selection: " + JSON.stringify(selection));
+  },
+};
+
+this.NSGetFactory = XPCOMUtils.generateNSGetFactory([ExampleComponent]);

--- a/components/components.manifest
+++ b/components/components.manifest
@@ -1,0 +1,3 @@
+component {20227a22-1722-4753-b8f7-c842b401b4c3} component.js
+contract @mozilla.org/embedlite-example-component;1 {20227a22-1722-4753-b8f7-c842b401b4c3}
+category app-startup ExampleComponent service,@mozilla.org/embedlite-example-component;1

--- a/harbour-webview.pro
+++ b/harbour-webview.pro
@@ -17,6 +17,9 @@ PKGCONFIG += qt5embedwidget
 
 SOURCES += src/harbour-webview.cpp
 
+PKGCONFIG += \
+    sailfishwebengine
+
 DISTFILES += qml/harbour-webview.qml \
     qml/cover/CoverPage.qml \
     qml/pages/WebViewPage.qml \
@@ -25,6 +28,8 @@ DISTFILES += qml/harbour-webview.qml \
     rpm/harbour-webview.spec \
     rpm/harbour-webview.yaml \
     translations/*.ts \
+    components/components.manifest \
+    components/*.js
     harbour-webview.desktop
 
 SAILFISHAPP_ICONS = 86x86 108x108 128x128 172x172
@@ -38,3 +43,8 @@ CONFIG += sailfishapp_i18n
 # following TRANSLATIONS line. And also do not forget to
 # modify the localized app name in the the .desktop file.
 TRANSLATIONS += translations/harbour-webview-de.ts
+
+components.path = /usr/share/$$TARGET/components/
+components.files = $$PWD/components/components.manifest $$PWD/components/*.js
+
+INSTALLS += components

--- a/qml/pages/WebViewPage.qml
+++ b/qml/pages/WebViewPage.qml
@@ -1,8 +1,9 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.WebView 1.0
+import Sailfish.WebEngine 1.0
 
-Page {
+WebViewPage {
     id: page
 
     // The effective value will be restricted by ApplicationWindow.allowedOrientations
@@ -11,6 +12,16 @@ Page {
     WebView {
         anchors.fill: parent
         active: true
-        url: "http://www.sailfishos.org"
+        url: "https://browser.sailfishos.org/tests/testpage.html"
+
+        onLinkClicked: {
+            console.log("Link clicked")
+            WebEngine.notifyObservers("exampleTopic", url)
+        }
+
+        Component.onCompleted: {
+            WebEngine.addComponentManifest("/usr/share/harbour-webview/components/components.manifest")
+            console.log("Component added")
+        }
     }
 }

--- a/src/harbour-webview.cpp
+++ b/src/harbour-webview.cpp
@@ -2,17 +2,52 @@
 
 #include <sailfishapp.h>
 
+#include "webenginesettings.h"
+
+static void showHelp()
+{
+    qDebug() << "Usage: cmd --help | [URL]...";
+}
+
 int main(int argc, char *argv[])
 {
-    // SailfishApp::main() will display "qml/harbour-webview.qml", if you need more
-    // control over initialization, you can use:
-    //
-    //   - SailfishApp::application(int, char *[]) to get the QGuiApplication *
-    //   - SailfishApp::createView() to get a new QQuickView * instance
-    //   - SailfishApp::pathTo(QString) to get a QUrl to a resource file
-    //   - SailfishApp::pathToMainQml() to get a QUrl to the main QML file
-    //
-    // To display the view, call "show()" (will show fullscreen on device).
+    bool execute = true;
+    int result = 0;
+    QString startUrl;
 
-    return SailfishApp::main(argc, argv);
+    qDebug() << "WebView Example";
+
+    if ((argc > 2) || ((argc == 2) && (strcmp("--help", argv[1]) == 0))) {
+        showHelp();
+        execute = false;
+    }
+
+    if (execute) {
+        if (argc == 2) {
+            startUrl = QString(argv[1]);
+            qDebug() << "Start URL set to: " << startUrl;
+        }
+        else {
+            startUrl = QStringLiteral("https://www.flypig.co.uk/search/");
+            qDebug() << "Using default start URL: " << startUrl;
+        }
+
+        qDebug() << "Opening webview";
+
+        QGuiApplication *app = SailfishApp::application(argc, argv);
+
+        QQuickView *view = SailfishApp::createView();
+        // The engine takes ownership of the ImageProvider
+        view->setSource(SailfishApp::pathTo("qml/harbour-webview.qml"));
+
+        QQmlContext *ctxt = view->rootContext();
+        ctxt->setContextProperty("startUrl", startUrl);
+        view->show();
+
+        SailfishOS::WebEngineSettings *webEngineSettings = SailfishOS::WebEngineSettings::instance();
+
+        result = app->exec();
+    }
+
+    return result;
 }


### PR DESCRIPTION
Adds a component that's useful for testing the PromptDialog components. Selecting a link on the page will trigger a dialog to open.

See gecko-dev/toolkit/components/windowwatcher/nsIPromptService.idl for the dialog parameters.

After installation the following file can be edited directly to test different prompts and parameters:
/usr/share/harbour-webview/components/component.js

This PR is intended only for testing purposes of the following PRs which must be applied for this to work:

https://github.com/sailfishos/embedlite-components/pull/5
https://github.com/sailfishos/sailfish-components-webview/pull/117